### PR TITLE
Fix encoding value bug

### DIFF
--- a/pyipp/__version__.py
+++ b/pyipp/__version__.py
@@ -1,3 +1,3 @@
 """Asynchronous Python client for IPP."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/pyipp/serializer.py
+++ b/pyipp/serializer.py
@@ -19,8 +19,9 @@ def __construct_attibute_values(tag: IppTag, value: Any) -> bytes:
         bs += struct.pack(">h", 1)
         bs += struct.pack(">?", value)
     else:
-        bs += struct.pack(">h", len(value))
-        bs += value.encode("utf-8")
+        encoded_value = value.encode("utf-8")
+        bs += struct.pack(">h", len(encoded_value))
+        bs += encoded_value
 
     return bs
 


### PR DESCRIPTION
If value is a string with Cyrillic characters that occupy 2 bytes in utf, then the number of bytes will be calculated incorrectly.