### PR TITLE
Adding printer-more-info support

### DIFF
--- a/pyipp/const.py
+++ b/pyipp/const.py
@@ -31,6 +31,7 @@ DEFAULT_PRINTER_ATTRIBUTES = [
     "printer-uri-supported",
     "device-uri",
     "printer-is-shared",
+    "printer-more-info",
 ]
 
 DEFAULT_PORT = 631

--- a/pyipp/models.py
+++ b/pyipp/models.py
@@ -25,6 +25,7 @@ class Info:
     serial: Optional[str] = None
     uuid: Optional[str] = None
     version: Optional[str] = None
+    more_info: Optional[str] = None
 
     @staticmethod
     def from_dict(data: dict):
@@ -83,6 +84,8 @@ class Info:
             uptime=data.get("printer-up-time", 0),
             uuid=uuid[9:] if uuid else None,  # strip urn:uuid: from uuid
             version=data.get("printer-firmware-string-version", None),
+            more_info=data.get("printer-more-info", None)
+
         )
 
 


### PR DESCRIPTION
I've been working on home assistant which is using your library and opened a pull request to allow users to browse to the printer more-info url if provided: https://github.com/home-assistant/core/pull/79313

As such we would need to implement this change into your library for the code changes I'm proposing to work.

Here is info on the more info section:
https://www.rfc-editor.org/rfc/rfc8011#section-5.4.7

```
[5.4.7](https://www.rfc-editor.org/rfc/rfc8011#section-5.4.7).  printer-more-info (uri)

   This RECOMMENDED Printer attribute contains a URI used to obtain more
   information about this specific Printer.  For example, this could be
   an HTTP URI referencing an HTML page accessible to a web browser.
   The information obtained from this URI is intended for End User
   consumption.  Features outside the scope of IPP can be accessed from
   this URI.  The information is intended to be specific to this Printer
   instance and site-specific services, e.g., Job pricing, services
   offered, and End User assistance.  The device manufacturer can
   initially populate this attribute.
```