### PR TITLE
fix: remove I/O in the event loop when creating IPP

### DIFF
--- a/src/pyipp/ipp.py
+++ b/src/pyipp/ipp.py
@@ -35,6 +35,7 @@ from .serializer import encode_dict
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+VERSION = metadata.version(__package__)
 
 @dataclass
 class IPP:
@@ -72,9 +73,7 @@ class IPP:
             self._printer_uri = self._build_printer_uri()
 
         if self.user_agent is None:
-            version = metadata.version(__package__)
-
-            self.user_agent = f"PythonIPP/{version}"
+            self.user_agent = f"PythonIPP/{VERSION}"
 
     async def _request(
         self,


### PR DESCRIPTION
Calling metadata.version does blocking disk I/O

![ipp_setup_again](https://github.com/ctalkington/python-ipp/assets/663432/11577506-787a-447e-803e-5520e6e147f9)
