### PR TITLE
Add ability to retrieve Printer model as dictionary

### DIFF
--- a/src/pyipp/models.py
+++ b/src/pyipp/models.py
@@ -2,7 +2,7 @@
 # pylint: disable=R0912,R0915
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from yarl import URL
@@ -145,6 +145,15 @@ class Printer:
     markers: list[Marker]
     state: State
     uris: list[Uri]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return dictionary version of this printer."""
+        return {
+            "info": asdict(self.info),
+            "state": asdict(self.state),
+            "markers": asdict(marker) for marker in self.markers],
+            "uris": asdict(uri) for uri in self.uris],
+        }
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> Printer:

--- a/src/pyipp/models.py
+++ b/src/pyipp/models.py
@@ -151,8 +151,8 @@ class Printer:
         return {
             "info": asdict(self.info),
             "state": asdict(self.state),
-            "markers": asdict(marker) for marker in self.markers],
-            "uris": asdict(uri) for uri in self.uris],
+            "markers": [asdict(marker) for marker in self.markers],
+            "uris": [asdict(uri) for uri in self.uris],
         }
 
     @staticmethod

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 # pylint: disable=R0912,R0915
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
 import pytest
 
@@ -193,6 +193,22 @@ async def test_printer() -> None:  # noqa: PLR0915
     assert printer.uris[1].authentication is None
     assert printer.uris[1].security is None
 
+def test_printer_as_dict() -> None:
+    """Test the dictionary version of Printer."""
+    parsed = parser.parse(load_fixture_binary("get-printer-attributes-epsonxp6000.bin"))
+    printer = models.Printer.from_dict(parsed["printers"][0])
+
+    assert printer
+
+    printer_dict = printer.as_dict()
+    assert printer_dict
+    assert isinstance(printer_dict, dict)
+    assert isinstance(printer_dict["info"], dict)
+    assert isinstance(printer_dict["state"], dict)
+    assert isinstance(printer_dict["markers"], List)
+    assert len(printer_dict["markers"]) == 8
+    assert isinstance(printet_dict["uris"], List)
+    assert len(printer_dict["uris"]) == 0
 
 @pytest.mark.asyncio
 async def test_printer_with_single_marker() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -207,7 +207,7 @@ def test_printer_as_dict() -> None:
     assert isinstance(printer_dict["state"], dict)
     assert isinstance(printer_dict["markers"], List)
     assert len(printer_dict["markers"]) == 8
-    assert isinstance(printet_dict["uris"], List)
+    assert isinstance(printer_dict["uris"], List)
     assert len(printer_dict["uris"]) == 0
 
 @pytest.mark.asyncio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -206,9 +206,9 @@ def test_printer_as_dict() -> None:
     assert isinstance(printer_dict["info"], dict)
     assert isinstance(printer_dict["state"], dict)
     assert isinstance(printer_dict["markers"], List)
-    assert len(printer_dict["markers"]) == 8
+    assert len(printer_dict["markers"]) == 5
     assert isinstance(printer_dict["uris"], List)
-    assert len(printer_dict["uris"]) == 0
+    assert len(printer_dict["uris"]) == 2
 
 @pytest.mark.asyncio
 async def test_printer_with_single_marker() -> None:


### PR DESCRIPTION
pre-req to support Home Assistant diagnostics