### PR TITLE
Fix printer `printer-state-reasons` attributes spelling mistakes

### DIFF
--- a/examples/debug.py
+++ b/examples/debug.py
@@ -23,7 +23,7 @@ async def main() -> None:
                         "printer-make-and-model",
                         "printer-state",
                         "printer-state-message",
-                        "printer-state-reason",
+                        "printer-state-reasons",
                         "printer-supply",
                         "printer-up-time",
                         "printer-uri-supported",

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -23,7 +23,7 @@ async def main() -> None:
                         "printer-make-and-model",
                         "printer-state",
                         "printer-state-message",
-                        "printer-state-reason",
+                        "printer-state-reasons",
                         "printer-supply",
                         "printer-up-time",
                         "printer-uri-supported",

--- a/src/pyipp/const.py
+++ b/src/pyipp/const.py
@@ -28,7 +28,7 @@ DEFAULT_PRINTER_ATTRIBUTES = [
     "printer-make-and-model",
     "printer-state",
     "printer-state-message",
-    "printer-state-reason",
+    "printer-state-reasons",
     "printer-supply",
     "printer-up-time",
     "printer-uri-supported",

--- a/src/pyipp/tags.py
+++ b/src/pyipp/tags.py
@@ -34,7 +34,6 @@ ATTRIBUTE_TAG_MAP = {
     "member-uris": IppTag.URI,
     "operations-supported": IppTag.ENUM,
     "ppd-name": IppTag.NAME,
-    "printer-state-reason": IppTag.KEYWORD,
     "printer-is-shared": IppTag.BOOLEAN,
     "printer-error-policy": IppTag.NAME,
     "printer-geo-location": IppTag.URI,


### PR DESCRIPTION
it is printer-state-reasons not printer-state-reason.

ipptool -tv ipp://printer:631/ipp/print get-printer-attributes.test

<img width="964" alt="截屏2025-05-29 23 39 02" src="https://github.com/user-attachments/assets/de979e79-5941-455f-9a02-94ea6224468c" />
