### PR TITLE
Add page counter support

### DIFF
--- a/src/pyipp/__init__.py
+++ b/src/pyipp/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
 )
 from .ipp import IPP
 from .models import (
+    Counters,
     Info,
     Marker,
     Printer,
@@ -17,6 +18,7 @@ from .models import (
 )
 
 __all__ = [
+    "Counters",
     "Info",
     "Marker",
     "Printer",

--- a/src/pyipp/const.py
+++ b/src/pyipp/const.py
@@ -42,6 +42,9 @@ DEFAULT_PRINTER_ATTRIBUTES = [
     "marker-low-levels",
     "marker-names",
     "marker-types",
+    "printer-impressions-completed",
+    "printer-pages-completed",
+    "printer-media-sheets-completed",
 ]
 
 DEFAULT_PORT = 631

--- a/src/pyipp/const.py
+++ b/src/pyipp/const.py
@@ -43,6 +43,7 @@ DEFAULT_PRINTER_ATTRIBUTES = [
     "marker-names",
     "marker-types",
     "printer-impressions-completed",
+    "printer-impressions-completed-col",
     "printer-pages-completed",
     "printer-media-sheets-completed",
 ]

--- a/src/pyipp/models.py
+++ b/src/pyipp/models.py
@@ -116,6 +116,24 @@ class Uri:
 
 
 @dataclass
+class Counters:
+    """Object holding page counter information from IPP."""
+
+    impressions_completed: int
+    pages_completed: int
+    media_sheets_completed: int
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> Counters:
+        """Return Counters object from IPP response."""
+        return Counters(
+            impressions_completed=data.get("printer-impressions-completed", -1),
+            pages_completed=data.get("printer-pages-completed", -1),
+            media_sheets_completed=data.get("printer-media-sheets-completed", -1),
+        )
+
+
+@dataclass
 class State:
     """Object holding the IPP printer state."""
 
@@ -143,6 +161,7 @@ class Printer:
     """Object holding the IPP printer information."""
 
     info: Info
+    counters: Counters
     markers: list[Marker]
     state: State
     uris: list[Uri]
@@ -152,6 +171,7 @@ class Printer:
         """Return dictionary version of this printer."""
         return {
             "info": asdict(self.info),
+            "counters": asdict(self.counters),
             "state": asdict(self.state),
             "markers": [asdict(marker) for marker in self.markers],
             "uris": [asdict(uri) for uri in self.uris],
@@ -163,6 +183,7 @@ class Printer:
         last_uptime = self.info.uptime
 
         self.info = Info.from_dict(data)
+        self.counters = Counters.from_dict(data)
         self.markers = Printer.merge_marker_data(data)
         self.state = State.from_dict(data)
         self.uris = Printer.merge_uri_data(data)
@@ -180,6 +201,7 @@ class Printer:
 
         return Printer(
             info=info,
+            counters=Counters.from_dict(data),
             markers=Printer.merge_marker_data(data),
             state=State.from_dict(data),
             uris=Printer.merge_uri_data(data),

--- a/src/pyipp/models.py
+++ b/src/pyipp/models.py
@@ -120,14 +120,24 @@ class Counters:
     """Object holding page counter information from IPP."""
 
     impressions_completed: int
+    impressions_completed_col: dict[str, int]
     pages_completed: int
     media_sheets_completed: int
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> Counters:
         """Return Counters object from IPP response."""
+        col = data.get("printer-impressions-completed-col", {})
+        if not isinstance(col, dict):
+            col = {}
+
+        impressions = data.get("printer-impressions-completed", -1)
+        if impressions == -1 and col:
+            impressions = sum(col.values())
+
         return Counters(
-            impressions_completed=data.get("printer-impressions-completed", -1),
+            impressions_completed=impressions,
+            impressions_completed_col=col,
             pages_completed=data.get("printer-pages-completed", -1),
             media_sheets_completed=data.get("printer-media-sheets-completed", -1),
         )

--- a/src/pyipp/tags.py
+++ b/src/pyipp/tags.py
@@ -62,4 +62,7 @@ ATTRIBUTE_TAG_MAP = {
     "media": IppTag.NAME,
     "center-of-pixel": IppTag.BOOLEAN,
     "sides": IppTag.KEYWORD,
+    "printer-impressions-completed": IppTag.INTEGER,
+    "printer-pages-completed": IppTag.INTEGER,
+    "printer-media-sheets-completed": IppTag.INTEGER,
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -344,6 +344,61 @@ async def test_printer_with_single_supported_uri_invalid_uri() -> None:
 
 
 @pytest.mark.asyncio
+async def test_counters() -> None:
+    """Test Counters model."""
+    data: dict[str, Any] = {
+        "printer-impressions-completed": 1234,
+        "printer-pages-completed": 5678,
+        "printer-media-sheets-completed": 9012,
+    }
+
+    counters = models.Counters.from_dict(data)
+
+    assert counters
+    assert counters.impressions_completed == 1234
+    assert counters.pages_completed == 5678
+    assert counters.media_sheets_completed == 9012
+
+
+@pytest.mark.asyncio
+async def test_counters_defaults() -> None:
+    """Test Counters model with missing data."""
+    counters = models.Counters.from_dict({})
+
+    assert counters
+    assert counters.impressions_completed == -1
+    assert counters.pages_completed == -1
+    assert counters.media_sheets_completed == -1
+
+
+@pytest.mark.asyncio
+async def test_printer_counters() -> None:
+    """Test Printer model includes counters."""
+    data = IPPE10_PRINTER_ATTRS.copy()
+    data["printer-impressions-completed"] = 500
+    data["printer-pages-completed"] = 400
+    data["printer-media-sheets-completed"] = 300
+
+    printer = models.Printer.from_dict(data)
+    assert printer
+    assert printer.counters.impressions_completed == 500
+    assert printer.counters.pages_completed == 400
+    assert printer.counters.media_sheets_completed == 300
+
+
+@pytest.mark.asyncio
+async def test_printer_counters_in_as_dict() -> None:
+    """Test Printer as_dict includes counters."""
+    data = IPPE10_PRINTER_ATTRS.copy()
+    data["printer-impressions-completed"] = 100
+
+    printer = models.Printer.from_dict(data)
+    printer_dict = printer.as_dict()
+    assert "counters" in printer_dict
+    assert printer_dict["counters"]["impressions_completed"] == 100
+
+
+@pytest.mark.asyncio
 async def test_printer_with_single_supported_uri_with_security() -> None:
     """Test Printer model with multiple markers."""
     data = IPPE10_PRINTER_ATTRS.copy()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -356,6 +356,7 @@ async def test_counters() -> None:
 
     assert counters
     assert counters.impressions_completed == 1234
+    assert counters.impressions_completed_col == {}
     assert counters.pages_completed == 5678
     assert counters.media_sheets_completed == 9012
 
@@ -367,8 +368,43 @@ async def test_counters_defaults() -> None:
 
     assert counters
     assert counters.impressions_completed == -1
+    assert counters.impressions_completed_col == {}
     assert counters.pages_completed == -1
     assert counters.media_sheets_completed == -1
+
+
+@pytest.mark.asyncio
+async def test_counters_col() -> None:
+    """Test Counters model with collection-based impressions."""
+    data: dict[str, Any] = {
+        "printer-impressions-completed-col": {
+            "monochrome": 0,
+            "full-color": 10,
+        },
+    }
+
+    counters = models.Counters.from_dict(data)
+
+    assert counters
+    assert counters.impressions_completed == 10
+    assert counters.impressions_completed_col == {"monochrome": 0, "full-color": 10}
+
+
+@pytest.mark.asyncio
+async def test_counters_col_does_not_override_scalar() -> None:
+    """Test that scalar impressions-completed takes precedence over col."""
+    data: dict[str, Any] = {
+        "printer-impressions-completed": 500,
+        "printer-impressions-completed-col": {
+            "monochrome": 100,
+            "full-color": 200,
+        },
+    }
+
+    counters = models.Counters.from_dict(data)
+
+    assert counters.impressions_completed == 500
+    assert counters.impressions_completed_col == {"monochrome": 100, "full-color": 200}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `Counters` dataclass exposing `printer-impressions-completed`, `printer-pages-completed`, and `printer-media-sheets-completed` IPP attributes
- Counters are requested by default and available via `printer.counters` on the `Printer` model
- Values default to `-1` when the printer doesn't report them (consistent with marker level conventions)

## Test plan
- [x] All existing model tests pass
- [x] New tests for `Counters.from_dict()` with data and with missing data
- [x] New tests for `Printer.counters` integration and `as_dict()` serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)