### PR TITLE
Add Python 3.12, 3.13, and 3.14 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: "poetry"
       - name: Install workflow dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Summary
- Add Python 3.12, 3.13, and 3.14 to the CI test matrix in `tests.yaml`
- Add `allow-prereleases: true` to `setup-python` for Python 3.14 support
- Add missing Python version classifiers (3.11, 3.12, 3.13, 3.14) in `pyproject.toml`

## Motivation
This component is used in HomeAssistant, which requires Python 3.14 support. The existing `python = "^3.9"` constraint in pyproject.toml already allows these versions — this PR adds the CI coverage and classifiers to match.

## Test plan
- [ ] CI passes for Python 3.9, 3.10, 3.11 (existing)
- [ ] CI passes for Python 3.12, 3.13 (new, stable)
- [ ] CI passes for Python 3.14 (new, pre-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)