### PR TITLE
Add 'print-scaling' tag to IppTag.KEYWORD

### DIFF
--- a/src/pyipp/tags.py
+++ b/src/pyipp/tags.py
@@ -62,4 +62,5 @@ ATTRIBUTE_TAG_MAP = {
     "media": IppTag.NAME,
     "center-of-pixel": IppTag.BOOLEAN,
     "sides": IppTag.KEYWORD,
+    "print-scaling": IppTag.KEYWORD,
 }


### PR DESCRIPTION
Without this, print scaling values are **silently** ignored.

Note it should be possible for implementers of PyIPP-based clients to specify the tag they want as part of the value in the dictionary.  Sad it isn't possible currently, but please consider changing the API to permit this.