### PR TITLE
Coerce list-valued printer-firmware-string-version to a string

### DIFF
--- a/src/pyipp/models.py
+++ b/src/pyipp/models.py
@@ -88,7 +88,7 @@ class Info:
             serial=serial,
             uptime=data.get("printer-up-time", 0),
             uuid=uuid[9:] if uuid else None,  # strip urn:uuid: from uuid
-            version=data.get("printer-firmware-string-version"),
+            version=_join_if_list(data.get("printer-firmware-string-version")),
             more_info=data.get("printer-more-info"),
         )
 
@@ -316,6 +316,17 @@ class Printer:
 def _utcnow() -> datetime:
     """Return the current date and time in UTC."""
     return datetime.now(tz=timezone.utc)
+
+def _join_if_list(value: Any) -> str | None:
+    """Return value joined into a single string if it is a list."""
+    if value is None:
+        return None
+
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+
+    return str(value)
+
 
 def _str_or_none(value: str) -> str | None:
     """Return string while handling string representations of None."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,6 +84,18 @@ async def test_info() -> None:  # noqa: PLR0915
 
 
 @pytest.mark.asyncio
+async def test_info_version_list() -> None:
+    """Test Info model with firmware version reported as multiple values."""
+    parsed = parser.parse(load_fixture_binary("get-printer-attributes-epsonxp6000.bin"))
+    data = parsed["printers"][0]
+    data["printer-firmware-string-version"] = ["2.0", "1.02", "CXNZJ.250.038"]
+    info = models.Info.from_dict(data)
+
+    assert info
+    assert info.version == "2.0, 1.02, CXNZJ.250.038"
+
+
+@pytest.mark.asyncio
 async def test_state() -> None:
     """Test State model."""
     data: dict[str, Any] = {


### PR DESCRIPTION
## Problem

Some printers (e.g. Lexmark MC2425adw, Brother MFC-L2710DN) report `printer-firmware-string-version` as multiple values (IPP `1setOf`), which the parser returns as a list. `Info.version` is annotated `str | None`, so consumers receive an unexpected `list` at runtime.

This surfaces in Home Assistant as a deprecation warning (soon an error in HA 2026.12) because the value is passed as `sw_version` to the device registry, which requires a string:

- Fixes #725
- Upstream report: home-assistant/core#172541 (the core-side fix home-assistant/core#172543 was closed as "awaiting upstream handling")

## Change

Join list values into a single comma-separated string in `Info.from_dict`, so `Info.version` always matches its `str | None` annotation. A single Lexmark printer reports e.g. `["2.0", "1.02", "1.7", "1.5", "CXNZJ.250.038"]`, which now becomes `"2.0, 1.02, 1.7, 1.5, CXNZJ.250.038"` instead of dropping information.

Includes a regression test.
